### PR TITLE
Fixed incorrect use of KEYS vs. ARGV

### DIFF
--- a/scripts/join.lua
+++ b/scripts/join.lua
@@ -1,6 +1,6 @@
 -- gets hashes by a foreign key list
 
-local limit = KEYS[3] or 0
+local limit = tonumber(ARGV[1]) or 0
 local ids = redis.call('lrange', KEYS[1], 0, limit - 1)
 local len = table.getn(ids)
 


### PR DESCRIPTION
The `KEYS` arrays is used to pass names of keys to the script. Anything else, use `ARGV`. Also, be explicit about the input you expect (hence `tonumber`).
